### PR TITLE
Fix for compatibility with Postgres 12 and cron notification update

### DIFF
--- a/covidtracker/commands/fetch_data.py
+++ b/covidtracker/commands/fetch_data.py
@@ -154,7 +154,7 @@ def fetch_data(
 
     print("Fetching grants")
     grant_sql = """
-        with g as (select * from view_latest_grant)
+        with g as MATERIALIZED (select * from view_latest_grant)
         select g.data->>'id' as "id",
             g.data->>'title' as "title",
             g.data->>'description' as "description",

--- a/cronfile.txt
+++ b/cronfile.txt
@@ -1,5 +1,5 @@
 # server cron jobs
-MAILTO="labs@threesixtygiving.org"
+MAILTO="360support@opendataservices.coop"
 PATH=/usr/local/bin:/usr/bin:/bin
 SHELL=/bin/bash
 
@@ -16,12 +16,12 @@ SHELL=/bin/bash
 ### PLACE ALL CRON TASKS BELOW
 
 # update with the latest data
-0 5 * * * dokku dokku --rm run covidtracker flask fetch-data
+0 5 * * * dokku dokku --rm run covidtracker flask fetch-data > /dev/null
 
 # clear the cache to make way for the new data
-45 5 * * * dokku dokku run covidtracker flask clear-cache
+45 5 * * * dokku dokku run covidtracker flask clear-cache > /dev/null
 
 # restart the application in the morning to load the new data
-0 6 * * * dokku dokku ps:rebuild covidtracker
+0 6 * * * dokku dokku ps:rebuild covidtracker > /dev/null
 
 ### PLACE ALL CRON TASKS ABOVE, DO NOT REMOVE THE WHITESPACE AFTER THIS LINE


### PR DESCRIPTION
**IMPORTANT: This PR breaks compatibility with Postgres <12 - please dokku lock older instances before merging**

As discussed as part of migration plan. With changes to the way views are handled in Postgres 12, a malformed date in some older data entries would cause the data fetch process to fail. This PR corrects that issue.

There are also some updates to the cron file in order to quiet it down unless something is written to stderr (i.e. python stacktrace or similar) and to update the contact email to the appropriate location.