### PR TITLE
allow for running fetch-data when no existing data is present (issue #27)

### DIFF
--- a/covidtracker/app.py
+++ b/covidtracker/app.py
@@ -38,9 +38,6 @@ with open(
 ) as a:
     app.index_string = a.read()
 
-all_data = get_data()
-data = filter_data(all_data)
-
 server.cli.add_command(fetch_data)
 
 
@@ -159,7 +156,7 @@ def get_all_grants_csv():
 
 
 app.title = "COVID-19 Grants Tracker"
-app.layout = layout(data, all_data)
+app.layout = layout()
 
 
 @app.callback(

--- a/covidtracker/data.py
+++ b/covidtracker/data.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import re
 
 import pandas as pd
@@ -10,16 +11,22 @@ pd.set_option("mode.chained_assignment", "raise")
 
 def get_data():
 
-    grants = pd.read_pickle(GRANTS_DATA_PICKLE)
-    words = pd.read_pickle(WORDS_PICKLE)
-
-    return dict(
-        grants=grants,
-        words=words,
+    results = dict(
+        grants=None,
+        words=None,
         now=datetime.datetime.now(),
-        last_updated=grants["_last_updated"].max().to_pydatetime(),
+        last_updated=datetime.datetime.now(),
         google_analytics=GOOGLE_ANALYTICS,
     )
+
+    if not os.path.exists(GRANTS_DATA_PICKLE):
+        return results
+
+    results["grants"] = pd.read_pickle(GRANTS_DATA_PICKLE)
+    results["words"] = pd.read_pickle(WORDS_PICKLE)
+    results["last_updated"] = results["grants"]["_last_updated"].max().to_pydatetime()
+
+    return results
 
 
 def normalise_string(s):

--- a/covidtracker/layout.py
+++ b/covidtracker/layout.py
@@ -1,6 +1,7 @@
 import dash_core_components as dcc
 import dash_html_components as html
 
+from .data import filter_data, get_data
 from .components import (
     cards,
     filters,
@@ -13,7 +14,11 @@ from .components import (
 )
 
 
-def layout(data, all_data):
+def layout():
+    all_data = get_data()
+    if not all_data["grants"]:
+        return html.Div("No data found")
+    data = filter_data(all_data)
     return html.Div(
         id="main-div",
         className="layout layout--single-column layout--full",


### PR DESCRIPTION
Running `flask fetch-data` requires the app layout to be set up which means running `get_data` which needs the grants data pickle file to exist. This changes the `get_data` function to return nothing if the pickle file doesn't already exist.

Note that if `flask fetch-data` is run when the grants data file doesn't already exist then any existing processes using `flask run` will need to be restarted - it won't automatically pick up that the file now exists. I think this is fine for any server deployments as `release_tasks.sh` which runs `flask fetch-data` is run before the process is restarted.